### PR TITLE
rootdir: init: Do not enable iostat_enable for f2fs by default

### DIFF
--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -861,7 +861,6 @@ on boot
     # are not aware of using fsync()/sync() to prepare sudden power-cut.
     write /sys/fs/f2fs/${dev.mnt.blk.data}/cp_interval 200
     write /sys/fs/f2fs/${dev.mnt.blk.data}/gc_urgent_sleep_time 50
-    write /sys/fs/f2fs/${dev.mnt.blk.data}/iostat_enable 1
 
     # limit discard size to 128MB in order to avoid long IO latency
     # for filesystem tuning first (dm or sda)


### PR DESCRIPTION
* Follow-up functions are quoted by f2fs-stable: https://github.com/jaegeuk/f2fs-stable/commit/eb5c6ea041f871e584bf7dde1990dff25dfb91d1
* The earliest submission of citations: https://github.com/jaegeuk/f2fs-stable/commit/ae2a6cc5233c34298a55e35e82d0f16c3c12d035

* This function is mainly used to detect the usage statistics of F2FS
* internal data blocks, This feature is only for developer use and is
* useless for most users. Disable it to reduce file system overhead.

* Original submission information:
* Revert "rootdir/init.rc: enable iostat by default"

* This reverts commit 767c723c25ad11af5de5a99be22ddcc082bcb29b.

BUG: 67832902
[Gerrit-stic-bq053-赵悦男-tj: commit-aosp-disable]
[Solution: Disable file system data statistics]
[Android Verson: 11-R]
[changes test: Normal start, iostat_enable is 0]

Signed-off-by: stic-server-open <1138705738@qq.com>
Change-Id: I89457b054179c47d68bbce379529d1a58ea0df47